### PR TITLE
Corregir crash al parsear Subject DN con comas en la razón social

### DIFF
--- a/Core/Certificate.cs
+++ b/Core/Certificate.cs
@@ -132,7 +132,10 @@ namespace Fiscalapi.Credentials.Core
         public List<KeyValuePair<string, string>> IssuerKeyValuePairs
         {
             get => _x509Certificate2.Issuer.Split(',')
-                .Select(x => new KeyValuePair<string, string>(x.Split('=')[0].Trim(), x.Split('=')[1].Trim())).ToList();
+                 .Select(x => x.Split('=', 2))
+                 .Where(parts => parts.Length == 2)
+                 .Select(parts => new KeyValuePair<string, string>(parts[0].Trim(), parts[1].Trim()))
+                 .ToList();
         }
 
         /// <summary>
@@ -151,7 +154,10 @@ namespace Fiscalapi.Credentials.Core
         public List<KeyValuePair<string, string>> SubjectKeyValuePairs
         {
             get => _x509Certificate2.Subject.Split(',')
-                .Select(x => new KeyValuePair<string, string>(x.Split('=')[0].Trim(), x.Split('=')[1].Trim())).ToList();
+                 .Select(x => x.Split('=', 2))
+                 .Where(parts => parts.Length == 2)
+                 .Select(parts => new KeyValuePair<string, string>(parts[0].Trim(), parts[1].Trim()))
+                 .ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
 El SAT emite certificados FIEL donde la razón social (O=) puede contener
 comas (ej: "SEMILLAS, HORTALIZAS Y FLORES"). El código anterior hacía
 Split(',') sobre el Subject completo y luego accedía a Split('=')[1]
 directamente, lanzando IndexOutOfRangeException cuando un fragmento no
 contenía '='.

 Solución: usar Split('=', 2) con máximo 2 partes y filtrar fragmentos
 sin '=' antes de mapear a KeyValuePair. Aplicado en SubjectKeyValuePairs
 e IssuerKeyValuePairs.

Esto resolvio mi problema al tratar con una razon social que lleva una coma en el nombre

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced certificate data parsing to handle edge cases with malformed components, preventing failures and improving overall stability when processing certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->