### PR TITLE
Fix/certificate subject index out of range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`Fiscalapi.Credentials` is a single-project .NET library (NuGet: `Fiscalapi.Credentials`) that wraps Mexican SAT cryptographic credentials — **CSD** (Certificado de Sello Digital) and **FIEL / e.firma** — so callers can sign/verify data, hash for the SAT XML mass-download service, and produce PFX (PKCS#12) bundles without shelling out to `openssl`.
+
+Target frameworks: `net8.0;net9.0`. Root namespace: `Fiscalapi.Credentials`. See `fiscalapi-credentials.csproj` — `GeneratePackageOnBuild=True`, so every `Release` build produces a `.nupkg`. The `<Version>` element there is the single source of truth (bump it to release a new version; the CI workflow extracts it from the csproj).
+
+## Commands
+
+```bash
+dotnet restore
+dotnet build --configuration Release           # also emits the .nupkg (GeneratePackageOnBuild)
+dotnet pack  --configuration Release --output ./nupkg
+```
+
+Publishing is handled by `.github/workflows/CICD.yml` (manual `workflow_dispatch`), which reads the version from the csproj and pushes to nuget.org using the `NUGET_KEY` secret.
+
+There is **no test project** in the solution — do not claim tests pass; there is nothing to run. If you add tests, add a new test project to `fiscalapi-credentials.sln`.
+
+## Architecture
+
+The public API is three cooperating classes in `Core/`, backed by small helpers in `Common/`.
+
+- **`Certificate`** (`Core/Certificate.cs`) — wraps a `.cer` (X.509 DER) supplied as a base64 string. Internally builds an `X509Certificate2` on construction and exposes SAT-relevant metadata (`Rfc`, `Organization`, `SerialNumber`, `CertificateNumber`, `ValidFrom`/`ValidTo`, `IsFiel()`, `IsValid()`). Also converts DER → PEM via `GetPemRepresentation()`.
+- **`PrivateKey`** (`Core/PrivateKey.cs`) — wraps a `.key` (PKCS#8 DER) plus its password. Handles DER → PEM conversion and low-level `SignData` / `VerifyData` using a caller-provided `HashAlgorithmName` and `RSASignaturePadding`.
+- **`Credential`** (`Core/Credential.cs`) — composes `ICertificate` + `IPrivateKey`. At construction it calls `X509Certificate2.CreateFromPem(PemCertificate, PemPrivateKey)` once and reuses that instance for `CreatePFX()`. Signing/verifying is delegated to the `PrivateKey`. The `CredentialType` (Csd vs Fiel) is derived from the certificate, not stored.
+
+Always program against the interfaces (`ICertificate`, `IPrivateKey`, `ICredential`) — the README and public surface are built around them.
+
+### Signature algorithm is instance state (thread-safety invariant)
+
+`Credential.SignatureAlgorithm` and `Credential.SignaturePadding` are **per-instance** properties, defaulting to `SHA256` + `Pkcs1`. Commit `fb11729` deliberately moved these off of a static `CredentialSettings` to avoid cross-thread mutation. Do **not** reintroduce static signature state. Use the fluent helpers to switch modes:
+
+- `ConfigureAlgorithmForInvoicing()` → `SHA256` (CFDI sealing).
+- `ConfigureAlgorithmForXmlDownloader()` → `SHA1` (SAT mass-download service).
+
+Note a quirk: `CreateHash` / `VerifyHash` are hard-coded to `SHA1` regardless of `SignatureAlgorithm`. If you need a SHA256 hash, don't assume `ConfigureAlgorithmForInvoicing()` changes hashing behavior.
+
+### `CredentialSettings.OriginalStringPath` (the one remaining static)
+
+`GetOriginalStringByXmlString` transforms a CFDI XML into its "cadena original" via `XslCompiledTransform`. The XSLT file path is read from the static `CredentialSettings.OriginalStringPath` — callers must set this once at startup (e.g. to the SAT-provided `cadenaoriginal_4_0.xslt`). It is intentionally static because the XSLT is a deployment artifact, not per-request state. The transformer enables `EnableDocumentFunction` and `EnableScript` because the official SAT XSLT uses both.
+
+### Input format convention
+
+Throughout the API, `.cer` and `.key` bytes are passed as **base64 strings**, not byte arrays or file paths. `Certificate.PlainBase64` and `PrivateKey.PlainBase64` preserve the original base64 so credentials can be round-tripped through a database without re-reading the files.
+
+## Conventions
+
+- Code and comments are a mix of Spanish (README, user-facing docs) and English (XML doc comments, identifiers). Match the surrounding file — don't translate one into the other mid-file.
+- `Common/HelpersToVerify.cs` is entirely commented-out legacy Chilkat code kept for historical reference; don't "clean it up" unless the user asks.
+- The README is packed into the NuGet (`<PackageReadmeFile>README.md</PackageReadmeFile>`), so README edits ship to NuGet consumers on the next release.

--- a/Core/Certificate.cs
+++ b/Core/Certificate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -9,13 +9,15 @@ using Fiscalapi.Credentials.Common;
 namespace Fiscalapi.Credentials.Core
 {
     /// <summary>
-    /// Represents a wrapper for FIEL and CSD certificate.
+    /// Wrapper for a SAT cryptographic certificate (FIEL/e.firma or CSD).
     /// </summary>
     public sealed class Certificate : ICertificate
     {
         private readonly X509Certificate2 _x509Certificate2;
 
-
+        /// <summary>
+        /// Initializes the certificate from the .cer file bytes encoded as base64.
+        /// </summary>
         public Certificate(string plainBase64)
         {
             PlainBase64 = plainBase64;
@@ -23,40 +25,35 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// The result of reading the bytes from the .cer file and converting them to base64
+        /// The .cer file bytes encoded as base64. Preserved so the credential can be round-tripped through storage.
         /// </summary>
         public string PlainBase64 { get; }
 
-
         /// <summary>
-        /// The equivalent of reading the bytes from the .cer file and converting them to base64
+        /// Decoded bytes of the .cer file (Convert.FromBase64String of PlainBase64).
         /// </summary>
         public byte[] CertificatePlainBytes
         {
             get => Convert.FromBase64String(PlainBase64);
         }
 
-
         /// <summary>
-        /// RFC as parsed from subject/x500UniqueIdentifier or OID.2.5.4.45
-        /// This ensures cross-platform compatibility (Windows/Linux).
+        /// RFC of the certificate holder, parsed from the subject's x500UniqueIdentifier (OID.2.5.4.45).
+        /// Cross-platform: Windows reports the key as "OID.2.5.4.45", Linux as "x500UniqueIdentifier".
         /// </summary>
         public string Rfc
         {
             get
             {
-                // Windows "OID.2.5.4.45"
                 var rfcPair = SubjectKeyValuePairs.FirstOrDefault(x =>
                     x.Key.Equals("OID.2.5.4.45", StringComparison.OrdinalIgnoreCase));
 
-                // Linux "x500UniqueIdentifier"
                 if (string.IsNullOrEmpty(rfcPair.Value))
                 {
                     rfcPair = SubjectKeyValuePairs.FirstOrDefault(x =>
                         x.Key.Equals("x500UniqueIdentifier", StringComparison.OrdinalIgnoreCase));
                 }
 
-                // First 13 chars
                 var value = rfcPair.Value;
 
                 if (!string.IsNullOrEmpty(value) && value.Length >= 12)
@@ -68,36 +65,33 @@ namespace Fiscalapi.Credentials.Core
             }
         }
 
-
         /// <summary>
-        /// Organization = 'razón social'
+        /// Razón social of the certificate holder, parsed from OID.2.5.4.41 ("name") with fallback to "O" (organizationName, OID.2.5.4.10).
+        /// Cross-platform: Windows reports the key as "OID.2.5.4.41", Linux as "name".
         /// </summary>
         public string Organization
         {
-            // CN: CommonName
-            // OU: OrganizationalUnit
-            // O: Organization
-            // L: Locality
-            // S: StateOrProvinceName
-            // C: CountryName
-            get => ExistsKey(SubjectKeyValuePairs, "O")
-                ? SubjectKeyValuePairs.FirstOrDefault(x => x.Key.Equals("O")).Value.Trim()
-                : string.Empty;
+            get
+            {
+                var pair = SubjectKeyValuePairs.FirstOrDefault(x =>
+                    x.Key.Equals("OID.2.5.4.41", StringComparison.OrdinalIgnoreCase) ||
+                    x.Key.Equals("name", StringComparison.OrdinalIgnoreCase));
+
+                if (string.IsNullOrEmpty(pair.Value))
+                {
+                    pair = SubjectKeyValuePairs.FirstOrDefault(x =>
+                        x.Key.Equals("O", StringComparison.OrdinalIgnoreCase));
+                }
+
+                return pair.Value?.Trim() ?? string.Empty;
+            }
         }
 
         /// <summary>
-        /// OrganizationalUnit = 'Sucursal'
-        /// As of 2019-08-01 is known that only CSD have OU (Organization Unit)
+        /// OrganizationalUnit ("Sucursal"). As of 2019-08-01 only CSDs have OU; FIEL certificates do not.
         /// </summary>
         public string OrganizationalUnit
         {
-            // CN: CommonName
-            // OU: OrganizationalUnit
-            // O: Organization
-            // L: Locality
-            // S: StateOrProvinceName
-            // C: CountryName
-
             get => ExistsKey(SubjectKeyValuePairs, "OU")
                 ? SubjectKeyValuePairs.FirstOrDefault(x => x.Key.Equals("OU")).Value.Trim()
                 : string.Empty;
@@ -108,9 +102,8 @@ namespace Fiscalapi.Credentials.Core
             return keyValuePairs.Any(pair => pair.Key.Equals(key));
         }
 
-
         /// <summary>
-        /// All serial number
+        /// Big-endian hexadecimal serial number reported by X509Certificate2.SerialNumber.
         /// </summary>
         public string SerialNumber
         {
@@ -118,54 +111,77 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// Certificate number as Mexican tax authority (SAT) require.
+        /// 20-digit ASCII "noCertificado" required by the SAT in CFDI sealing
+        /// (raw serial bytes reversed to little-endian and decoded as ASCII).
         /// </summary>
         public string CertificateNumber
         {
             get => Encoding.ASCII.GetString(_x509Certificate2.GetSerialNumber().Reverse().ToArray());
         }
 
-
         /// <summary>
-        /// Issuer data parsed into KeyValuePair collection
+        /// Issuer DN parsed into key/value pairs (key is Oid.FriendlyName when available, otherwise "OID.&lt;value&gt;").
         /// </summary>
         public List<KeyValuePair<string, string>> IssuerKeyValuePairs
         {
-            get => _x509Certificate2.Issuer.Split(',')
-                .Select(x => new KeyValuePair<string, string>(x.Split('=')[0].Trim(), x.Split('=')[1].Trim())).ToList();
+            get => ParseDistinguishedName(_x509Certificate2.IssuerName);
         }
 
         /// <summary>
-        /// Raw X509Certificate2 Issuer property
+        /// Issuer DN as a single string (X509Certificate2.Issuer).
         /// </summary>
         public string Issuer
         {
             get => _x509Certificate2.Issuer;
         }
 
-
         /// <summary>
-        /// Subject data parsed into KeyValuePair collection
-        /// see https://oidref.com/2.5.4.45
+        /// Subject DN parsed into key/value pairs (key is Oid.FriendlyName when available, otherwise "OID.&lt;value&gt;").
         /// </summary>
         public List<KeyValuePair<string, string>> SubjectKeyValuePairs
         {
-            get => _x509Certificate2.Subject.Split(',')
-                .Select(x => new KeyValuePair<string, string>(x.Split('=')[0].Trim(), x.Split('=')[1].Trim())).ToList();
+            get => ParseDistinguishedName(_x509Certificate2.SubjectName);
         }
 
         /// <summary>
-        /// Raw X509Certificate2 Subject property
-        /// see https://oidref.com/2.5.4.45
+        /// Parses an X.500 distinguished name into key/value pairs, honoring RFC 2253 escaping
+        /// (avoids the IndexOutOfRangeException that string.Split(',') hits on values with literal commas).
+        /// </summary>
+        private static List<KeyValuePair<string, string>> ParseDistinguishedName(X500DistinguishedName dn)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+
+            foreach (var rdn in dn.EnumerateRelativeDistinguishedNames())
+            {
+                if (rdn.HasMultipleElements)
+                    continue;
+
+                var oid = rdn.GetSingleElementType();
+                var value = rdn.GetSingleElementValue();
+
+                if (value is null)
+                    continue;
+
+                var key = !string.IsNullOrEmpty(oid.FriendlyName)
+                    ? oid.FriendlyName
+                    : $"OID.{oid.Value}";
+
+                result.Add(new KeyValuePair<string, string>(key, value));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Subject DN as a single string (X509Certificate2.Subject).
         /// </summary>
         public string Subject
         {
             get => _x509Certificate2.Subject;
         }
 
-
         /// <summary>
-        /// Certificate version
+        /// X.509 format version (typically 3 for SAT-issued certificates).
         /// </summary>
         public int Version
         {
@@ -173,7 +189,7 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// Valid start date
+        /// NotBefore (certificate effective date) in local time.
         /// </summary>
         public DateTime ValidFrom
         {
@@ -181,7 +197,7 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// Valid end date
+        /// NotAfter (certificate expiration date) in local time.
         /// </summary>
         public DateTime ValidTo
         {
@@ -189,7 +205,7 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// True if ValidTo date is less than the current date
+        /// True when ValidTo is in the future (compared against DateTime.Now).
         /// </summary>
         public bool IsValid()
         {
@@ -197,16 +213,15 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// True when is a FIEL certificate
+        /// True when the certificate is a FIEL/e.firma, identified by the absence of an OrganizationalUnit.
         /// </summary>
         public bool IsFiel()
         {
             return string.IsNullOrEmpty(OrganizationalUnit);
         }
 
-
         /// <summary>
-        /// Raw Data Length
+        /// Length in bytes of the raw DER-encoded certificate.
         /// </summary>
         public int RawDataLength
         {
@@ -214,7 +229,7 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// RawDataBytes
+        /// Raw DER-encoded certificate bytes.
         /// </summary>
         public byte[] RawDataBytes
         {
@@ -222,14 +237,40 @@ namespace Fiscalapi.Credentials.Core
         }
 
         /// <summary>
-        /// Convert X.509 DER base64 or X.509 DER to X.509 PEM
+        /// Converts the X.509 DER (or its base64 form) to X.509 PEM.
         /// </summary>
-        /// <returns></returns>
         public string GetPemRepresentation()
         {
             var certPem = new string(PemEncoding.Write(Flags.PemCertificate, _x509Certificate2.RawData));
 
             return certPem;
+        }
+
+        /// <summary>
+        /// True when this certificate and the given RSA private key form a matching pair
+        /// (compares the modulus and exponent of the public keys).
+        /// </summary>
+        public bool ArePaired(RSA privateKey)
+        {
+            if (privateKey is null)
+                return false;
+
+            try
+            {
+                using var certificatePublicKey = _x509Certificate2.GetRSAPublicKey();
+                if (certificatePublicKey is null)
+                    return false;
+
+                var certParams = certificatePublicKey.ExportParameters(includePrivateParameters: false);
+                var keyParams = privateKey.ExportParameters(includePrivateParameters: false);
+
+                return certParams.Modulus.AsSpan().SequenceEqual(keyParams.Modulus)
+                    && certParams.Exponent.AsSpan().SequenceEqual(keyParams.Exponent);
+            }
+            catch (CryptographicException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/Core/Credential.cs
+++ b/Core/Credential.cs
@@ -215,7 +215,7 @@ public class Credential : ICredential
         var xsltSettings = new XsltSettings
         {
             EnableDocumentFunction = true,
-            EnableScript = true
+            //EnableScript = true
         };
         var resolver = new XmlUrlResolver();
         var transformer = new XslCompiledTransform();

--- a/Core/ICertificate.cs
+++ b/Core/ICertificate.cs
@@ -1,28 +1,31 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 
 namespace Fiscalapi.Credentials.Core;
 
+/// <summary>
+/// Read-only view of a SAT cryptographic certificate (FIEL/e.firma or CSD).
+/// </summary>
 public interface ICertificate
 {
     /// <summary>
-    /// The result of reading the bytes from the .cer file and converting them to base64
+    /// The .cer file bytes encoded as base64. Preserved so the credential can be round-tripped through storage.
     /// </summary>
     string PlainBase64 { get; }
 
     /// <summary>
-    /// The equivalent of reading the bytes from the .cer file and converting them to base64
+    /// Decoded bytes of the .cer file (Convert.FromBase64String of PlainBase64).
     /// </summary>
     byte[] CertificatePlainBytes { get; }
 
     /// <summary>
-    /// RFC as parsed from subject/x500UniqueIdentifier 
-    /// see https://oidref.com/2.5.4.45
+    /// RFC of the certificate holder, parsed from the subject's x500UniqueIdentifier (OID.2.5.4.45).
     /// </summary>
     string Rfc { get; }
 
     /// <summary>
-    /// Organization = 'razón social'
+    /// Razón social of the certificate holder (OID.2.5.4.41 with fallback to "O").
     /// </summary>
     string Organization
     {
@@ -36,8 +39,7 @@ public interface ICertificate
     }
 
     /// <summary>
-    /// OrganizationalUnit = 'Sucursal'
-    /// As of 2019-08-01 is known that only CSD have OU (Organization Unit)
+    /// OrganizationalUnit ("Sucursal"). As of 2019-08-01 only CSDs have OU; FIEL certificates do not.
     /// </summary>
     string OrganizationalUnit
     {
@@ -47,80 +49,82 @@ public interface ICertificate
         // L: Locality
         // S: StateOrProvinceName
         // C: CountryName
-
         get;
     }
 
     /// <summary>
-    /// All serial number
+    /// Big-endian hexadecimal serial number reported by X509Certificate2.SerialNumber.
     /// </summary>
     string SerialNumber { get; }
 
     /// <summary>
-    /// Certificate number as Mexican tax authority (SAT) require.
+    /// 20-digit ASCII "noCertificado" required by the SAT in CFDI sealing.
     /// </summary>
     string CertificateNumber { get; }
 
     /// <summary>
-    /// Issuer data parsed into KeyValuePair collection
+    /// Issuer DN parsed into key/value pairs (key is Oid.FriendlyName when available, otherwise "OID.&lt;value&gt;").
     /// </summary>
     List<KeyValuePair<string, string>> IssuerKeyValuePairs { get; }
 
     /// <summary>
-    /// Raw X509Certificate2 Issuer property
+    /// Issuer DN as a single string (X509Certificate2.Issuer).
     /// </summary>
     string Issuer { get; }
 
     /// <summary>
-    /// Subject data parsed into KeyValuePair collection
-    /// see https://oidref.com/2.5.4.45
+    /// Subject DN parsed into key/value pairs (key is Oid.FriendlyName when available, otherwise "OID.&lt;value&gt;").
     /// </summary>
     List<KeyValuePair<string, string>> SubjectKeyValuePairs { get; }
 
     /// <summary>
-    /// Raw X509Certificate2 Subject property
-    /// see https://oidref.com/2.5.4.45
+    /// Subject DN as a single string (X509Certificate2.Subject).
     /// </summary>
     string Subject { get; }
 
     /// <summary>
-    /// Certificate version
+    /// X.509 format version (typically 3 for SAT-issued certificates).
     /// </summary>
     int Version { get; }
 
     /// <summary>
-    /// Valid start date
+    /// NotBefore (certificate effective date) in local time.
     /// </summary>
     DateTime ValidFrom { get; }
 
     /// <summary>
-    /// Valid end date
+    /// NotAfter (certificate expiration date) in local time.
     /// </summary>
     DateTime ValidTo { get; }
 
     /// <summary>
-    /// Raw Data Length
+    /// Length in bytes of the raw DER-encoded certificate.
     /// </summary>
     int RawDataLength { get; }
 
     /// <summary>
-    /// RawDataBytes
+    /// Raw DER-encoded certificate bytes.
     /// </summary>
     byte[] RawDataBytes { get; }
 
     /// <summary>
-    /// True if ValidTo date is less than the current date
+    /// True when ValidTo is in the future (compared against DateTime.Now).
     /// </summary>
     bool IsValid();
 
     /// <summary>
-    /// True when is a FIEL certificate
+    /// True when the certificate is a FIEL/e.firma, identified by the absence of an OrganizationalUnit.
     /// </summary>
     bool IsFiel();
 
     /// <summary>
-    /// Convert X.509 DER base64 or X.509 DER to X.509 PEM
+    /// Converts the X.509 DER (or its base64 form) to X.509 PEM.
     /// </summary>
-    /// <returns></returns>
     string GetPemRepresentation();
+
+    /// <summary>
+    /// True when this certificate and the given RSA private key form a matching pair
+    /// (compares the modulus and exponent of the public keys).
+    /// </summary>
+    bool ArePaired(RSA privateKey);
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fiscalapi Credentials
-[![.NET](https://img.shields.io/badge/.NET-6.0-purple.svg)](https://dotnet.microsoft.com/download/dotnet/6.0)
 [![.NET](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/download/dotnet/8.0)
 [![.NET](https://img.shields.io/badge/.NET-9.0-purple.svg)](https://dotnet.microsoft.com/download/dotnet/9.0)
+[![.NET](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/download/dotnet/10.0)
 [![Nuget](https://img.shields.io/nuget/v/Fiscalapi.Credentials)](https://www.nuget.org/packages/Fiscalapi.Credentials)
 [![License](https://img.shields.io/github/license/FiscalAPI/fiscalapi-credentials-net)](https://github.com/FiscalAPI/fiscalapi-credentials-net/blob/main/LICENSE)
 
@@ -159,7 +159,7 @@ Por lo tanto, no necesitas realizar la conversión manual ni depender de utiler�
 
 ## Compatibilidad
 
-- Compatible con **.NET 6**, **.NET 8** y **.NET 9**  WinForms, WPF, Console, ASP.NET, Blazor, MVC, WebApi.   
+- Compatible con **.NET 8**, **.NET 9** y **.NET 10**  WinForms, WPF, Console, ASP.NET, Blazor, MVC, WebApi.   
 - Mantenemos la compatibilidad con al menos la versión LTS más reciente de .NET.  
 - Se sigue el [**Versionado Semántico 2.0.0**]([docs/SEMVER.md](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort)), por lo que puedes confiar en que las versiones nuevas no romperán tu aplicación de forma inesperada.
 ## Roadmap

--- a/fiscalapi-credentials.csproj
+++ b/fiscalapi-credentials.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <Version>4.0.387</Version>
 	  <AssemblyVersion>$(Version)</AssemblyVersion>
 	  <FileVersion>$(Version)</FileVersion>

--- a/fiscalapi-credentials.csproj
+++ b/fiscalapi-credentials.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-	  <Version>4.0.340</Version>
+	  <Version>4.0.387</Version>
 	  <AssemblyVersion>$(Version)</AssemblyVersion>
 	  <FileVersion>$(Version)</FileVersion>
 	  <PackageVersion>$(Version)</PackageVersion>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added certificate-to-private-key pairing validation method.

* **Documentation**
  * Updated .NET framework support (now .NET 8, 9, 10).
  * Added development guidelines documentation.

* **Bug Fixes**
  * Disabled script execution in XSLT transformation for improved security.

* **Chores**
  * Version bumped to 4.0.387.
  * Added .NET 10 target framework support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FiscalAPI/fiscalapi-credentials-net/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->